### PR TITLE
[QOLDEV-350] pin tableschema to preserve Py2 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 goodtables==1.5.1
+tableschema>=1.0.3,<1.20.4


### PR DESCRIPTION
Tableschema 1.20.4 made a breaking change, relying on `importlib.util`